### PR TITLE
Fix unable to generate https url

### DIFF
--- a/lib/kinu.rb
+++ b/lib/kinu.rb
@@ -9,7 +9,7 @@ module Kinu
 
   def self.base_uri
     raise "Kinu.config.host is not set." if config.host.empty?
-    URI::HTTP.build(scheme: config.scheme, host: config.host, port: config.port)
+    URI::Generic.build(scheme: config.scheme.to_s, host: config.host, port: config.port)
   end
 
   def self.configure


### PR DESCRIPTION
`URI::HTTP.build` だとhttpsなURIを生成することができないみたいです。
`URI::Generic.build`を使うとhttp/https両方のスキーマに対応できそうなので、そちらを使ってみるのはどうでしょうか。

```ruby
$ pry
[1] pry(main)> require 'uri'
=> true
[2] pry(main)> URI::HTTP.build(scheme: :https, host: 'example.com', port: 443)
=> #<URI::HTTP http://example.com:443>
[3] pry(main)> URI::HTTP.build(scheme: :https, host: 'example.com', port: 443).to_s
=> "http://example.com:443"
[4] pry(main)> URI::Generic.build(scheme: 'https', host: 'example.com', port: 443)
=> #<URI::Generic https://example.com:443>
[5] pry(main)> URI::Generic.build(scheme: 'https', host: 'example.com', port: 443).to_s
=> "https://example.com:443"
[6] pry(main)> URI::Generic.build(scheme: :https, host: 'example.com', port: 443)
=> #<URI::Generic:0x3fe5ae939f94>
[7] pry(main)> URI::Generic.build(scheme: :https, host: 'example.com', port: 443).to_s
TypeError: no implicit conversion of Symbol into String
from /Users/tomoki-yamashita/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/generic.rb:1346:in `to_s'
```