### PR TITLE
Avoid URI::Generic can not respond to request_uri

### DIFF
--- a/lib/kinu.rb
+++ b/lib/kinu.rb
@@ -9,7 +9,7 @@ module Kinu
 
   def self.base_uri
     raise "Kinu.config.host is not set." if config.host.empty?
-    URI::Generic.build(scheme: config.scheme.to_s, host: config.host, port: config.port)
+    URI::Generic.build(scheme: config.scheme.to_s, host: config.host, port: config.port).to_s
   end
 
   def self.configure


### PR DESCRIPTION
A bug including due to no testing on https://github.com/tokubai/kinu-ruby/pull/1 🙇 
URI::Generic can not respond to request_uri...

```
[10] pry(main)> Kinu::Resource.new('onigiri', 1).upload(file)
NoMethodError: undefined method `request_uri' for #<URI::Generic https://example.com:443/upload>
from /path/to/rails-app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/adapter/net_http.rb:66:in `create_request'
```


