### PR TITLE
Fix upload error

### DIFF
--- a/lib/kinu.rb
+++ b/lib/kinu.rb
@@ -9,7 +9,7 @@ module Kinu
 
   def self.base_uri
     raise "Kinu.config.host is not set." if config.host.empty?
-    URI::Generic.build(scheme: config.scheme.to_s, host: config.host, port: config.port).to_s
+    (config.ssl? ? URI::HTTPS : URI::HTTP).build(host: config.host, port: config.port)
   end
 
   def self.configure


### PR DESCRIPTION
https://github.com/tokubai/kinu-ruby/pull/2 was a not good solution... it have a issue like this.

```ruby
[1] pry(main)> Kinu.configure do |config|
[1] pry(main)*   config.host = 'example.com'
[1] pry(main)*   config.ssl = true
[1] pry(main)* end
=> true
[2] pry(main)>
[3] pry(main)> resource = Kinu::Resource.new('onigiri', 1)
=> #<Kinu::Resource:0x007fca82b9dc10 @id=1, @name="onigiri">
[4] pry(main)> resource.uri(width: 100, height: 100, crop: true)
NoMethodError: undefined method `path=' for "https://example.com:443":String
Did you mean?  Pathname
from /Users/tomoki-yamashita/dev/ghq/github.com/tokubai/kinu-ruby/lib/kinu/resource_base.rb:35:in `build_uri'
```

Kinu.base_uri must return `URI::HTTP` or `URI::HTTPS`.

If you guys have another better solution. please do refactor 🙇 