### PR TITLE
Support manual cropping

### DIFF
--- a/lib/kinu/geometry.rb
+++ b/lib/kinu/geometry.rb
@@ -7,6 +7,12 @@ module Kinu
       crop:     :c,
       original: :o,
       middle:   :m,
+      manual_crop: :mc,
+      width_offset: :wo,
+      height_offset: :ho,
+      crop_width: :cw,
+      crop_height: :ch,
+      assumption_width: :aw,
     }.freeze
 
     def initialize(options)


### PR DESCRIPTION
The Geometry class is not supported manual cropping. Currently those options are ignored.
Manual cropping will be available when this pull request merged.

I think hash key is a little bit long. I don't mind if you wanna change the keys to be short. If so, please let me know. @TakatoshiMaeda @wata-gh 