### PR TITLE
Fix Kinu::HttpClient#respond_to? to suppress deprecation warning

### DIFF
--- a/lib/kinu/http_client.rb
+++ b/lib/kinu/http_client.rb
@@ -70,8 +70,8 @@ module Kinu
         File.basename(@file.path)
       end
 
-      def respond_to?(name)
-        io.respond_to?(name)
+      def respond_to?(name, include_all = false)
+        io.respond_to?(name, include_all)
       end
 
       def method_missing(*args)


### PR DESCRIPTION
I found that kinu-ruby issues the following warning.

> warning: Kinu::HttpClient::UploadFile#respond_to?(:to_ary) uses the deprecated method signature, which takes one parameter

This PR suppresses it.