### PR TITLE
Add support allow geometry options manual crop with original

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Added
+      labels:
+        - add
+    - title: Changed
+      labels:
+        - change
+    - title: Removed
+      labels:
+        - remove
+    - title: Others
+      labels:
+        - "*"

--- a/kinu.gemspec
+++ b/kinu.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday"
+  spec.add_dependency "faraday-multipart"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kinu/geometry.rb
+++ b/lib/kinu/geometry.rb
@@ -5,14 +5,14 @@ module Kinu
       height:   :h,
       quality:  :q,
       crop:     :c,
-      original: :o,
-      middle:   :m,
       manual_crop: :mc,
       width_offset: :wo,
       height_offset: :ho,
       crop_width: :cw,
       crop_height: :ch,
       assumption_width: :aw,
+      original: :o,
+      middle:   :m,
     }.freeze
 
     def initialize(options)

--- a/lib/kinu/http_client.rb
+++ b/lib/kinu/http_client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday/multipart'
 require 'kinu/errors'
 
 module Kinu

--- a/lib/kinu/version.rb
+++ b/lib/kinu/version.rb
@@ -1,3 +1,3 @@
 module Kinu
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/spec/kinu/resource_base_spec.rb
+++ b/spec/kinu/resource_base_spec.rb
@@ -57,6 +57,62 @@ module Kinu
         end
       end
 
+      context 'with manual crop option' do
+        let(:height) { 100 }
+        let(:width) { 100 }
+        let(:width_offset) { 10 }
+        let(:height_offset) { 10 }
+        let(:crop_width) { 80 }
+        let(:crop_height) { 80 }
+        let(:assumption_width) { 100 }
+        let(:geometry) do
+          {
+            width: width,
+            height: height,
+            width_offset: width_offset,
+            height_offset: height_offset,
+            crop_width: crop_width,
+            crop_height: crop_height,
+            assumption_width: assumption_width,
+          }
+        end
+        let(:uri) do
+          URI::HTTP.build(
+            host: hostname,
+            path: "/images/#{name}/w=#{width},h=#{height},wo=#{width_offset},ho=#{height_offset},cw=#{crop_width},ch=#{crop_height},aw=#{assumption_width}/#{id}.jpg"
+          )
+        end
+
+        it 'returns uri' do
+          is_expected.to eq(uri)
+        end
+
+        context 'with original' do
+          let(:geometry) do
+            {
+              width: width,
+              height: height,
+              width_offset: width_offset,
+              height_offset: height_offset,
+              crop_width: crop_width,
+              crop_height: crop_height,
+              assumption_width: assumption_width,
+              original: true,
+            }
+          end
+          let(:uri) do
+            URI::HTTP.build(
+              host: hostname,
+              path: "/images/#{name}/w=#{width},h=#{height},wo=#{width_offset},ho=#{height_offset},cw=#{crop_width},ch=#{crop_height},aw=#{assumption_width},o=true/#{id}.jpg"
+            )
+          end
+
+          it 'returns uri' do
+            is_expected.to eq(uri)
+          end
+        end
+      end
+
       context 'with middle' do
         let(:geometry) { { middle: true } }
         let(:uri) { URI::HTTP.build(host: hostname, path: "/images/#{name}/m=true/#{id}.jpg") }


### PR DESCRIPTION
## Backgrounds & Changes
During the renovation of  [kinu](https://github.com/tokubai/kinu/pull/75), we will allow URLs like the following.

`/images/{model_name}/w=300,h=300,mc=true,wo=761,ho=1323,cw=354,ch=374,aw=2787,o=true/{id}.jpg`

- Added option to use original image when manually cropping in kinu.
The order of each option in the above url was clearly defined in kinu, and the order was inconsistent within kinu-ruby, so this has been fixed.

- Added dependency `faraday-multipart`

## backward compatibility
I have not been able to specify both MANUAL CROPS and ORIGNIAL parameters before,
I assume that there will be no impact.

## Sample codes
​
```ruby
require 'kinu'
​
Kinu.configure do |c|
  c.host = 'image.tokubai.co.jp'
  c.port = nil
  c.ssl  = true
end
resource = Kinu::Resource.new(:bargain_cooking_recipes, 1000)
```
​
### Case1. manual crop default
```ruby
# before
resource.uri(width: 280, height: 300, manual_crop: true, width_offset: 761, height_offset: 1323, crop_width: 354, crop_height: 374, assumption_width: 2787).to_s
=> "https://image.tokubai.co.jp/images/bargain_cooking_recipes/w=280,h=300,mc=true,wo=761,ho=1323,cw=354,ch=374,aw=2787/1000.jpg"
​
# after
Not changed.
```
​
### Case2. manual crop with original
```ruby
# before
resource.uri(width: 280, height: 300, manual_crop: true, width_offset: 761, height_offset: 1323, crop_width: 354, crop_height: 374, assumption_width: 2787, original: true).to_s
=> "https://image.tokubai.co.jp/images/bargain_cooking_recipes/w=280,h=300,o=true,mc=true,wo=761,ho=1323,cw=354,ch=374,aw=2787/1000.jpg"
# --> An HTTP 404 error is returned.
​
# after
=> "https://image.tokubai.co.jp/images/bargain_cooking_recipes/w=280,h=300,mc=true,wo=761,ho=1323,cw=354,ch=374,aw=2787,o=true/1000.jpg"
# --> Currently, it returns the same as specifying only o=true. After kinu will have modified, so it returns manual crop with original image.
```

## release message

```
Added option to use original image when manually cropping.
```